### PR TITLE
fix nullref in obsolete code

### DIFF
--- a/DXVcs2Git.UI/Views/RepositoriesControl.xaml
+++ b/DXVcs2Git.UI/Views/RepositoriesControl.xaml
@@ -15,11 +15,6 @@
     <UserControl.DataContext>
         <extensions:IoC TargetType="{x:Type viewModels:EditRepositoriesViewModel}"/>
     </UserControl.DataContext>
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <selectors:RepositoriesControlImageSelector x:Key="imageSelector"/>
-        </ResourceDictionary>
-    </UserControl.Resources>
     <Grid>
         <dxg:GridControl ShowBorder="False" ItemsSource="{Binding Path=Items}" SelectedItem="{Binding Path=SelectedItem, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
             <dxg:GridControl.Columns>
@@ -31,7 +26,6 @@
                     ShowHorizontalLines="False"
                     ImageFieldName="HasMergeRequest"
                     ShowNodeImages="false"
-                    NodeImageSelector="{StaticResource imageSelector}"
                     ShowColumnHeaders="False"
                     AutoExpandAllNodes="True" 
                     TreeDerivationMode="ChildNodesSelector" 


### PR DESCRIPTION
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at DXVcs2Git.UI.Selectors.RepositoriesControlImageSelector.Select(TreeListRowData rowData)